### PR TITLE
Support nginx 1.28+/1.30 (guarded API compatibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ An nginx module that adds SOCKS5 proxy support to `proxy_pass`.
 
 ## Building
 
-Requires nginx **1.26.x** and PCRE2.
+Supports nginx stable branches **1.26.x, 1.28.x, and 1.30.x**. PCRE2 is required.
 
 ```bash
 git clone https://github.com/dannote/socks-nginx-module
-wget http://nginx.org/download/nginx-1.26.3.tar.gz
-tar -xzf nginx-1.26.3.tar.gz
-cd nginx-1.26.3
+wget https://nginx.org/download/nginx-1.30.4.tar.gz
+tar -xzf nginx-1.30.4.tar.gz
+cd nginx-1.30.4
 
 ./configure --add-dynamic-module=../socks-nginx-module
 make

--- a/ngx_http_proxy_module.h
+++ b/ngx_http_proxy_module.h
@@ -1436,7 +1436,11 @@ ngx_http_proxy_chunked_filter(ngx_event_pipe_t *p, ngx_buf_t *buf)
 
     for ( ;; ) {
 
+#if (nginx_version >= 1028000)
+        rc = ngx_http_parse_chunked(r, buf, &ctx->chunked, 0);
+#else
         rc = ngx_http_parse_chunked(r, buf, &ctx->chunked);
+#endif
 
         if (rc == NGX_OK) {
 
@@ -1641,7 +1645,11 @@ ngx_http_proxy_non_buffered_chunked_filter(void *data, ssize_t bytes)
 
     for ( ;; ) {
 
+#if (nginx_version >= 1028000)
+        rc = ngx_http_parse_chunked(r, buf, &ctx->chunked, 0);
+#else
         rc = ngx_http_parse_chunked(r, buf, &ctx->chunked);
+#endif
 
         if (rc == NGX_OK) {
 

--- a/ngx_http_socks_upstream.h
+++ b/ngx_http_socks_upstream.h
@@ -2488,7 +2488,11 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
     p->downstream = c;
     p->pool = r->pool;
     p->log = c->log;
+#if (nginx_version >= 1028000)
+    p->limit_rate = ngx_http_complex_value_size(r, u->conf->limit_rate, 0);
+#else
     p->limit_rate = u->conf->limit_rate;
+#endif
     p->start_sec = ngx_time();
 
     p->cacheable = u->cacheable || u->store;
@@ -4017,6 +4021,9 @@ ngx_http_upstream_ssl_certificate(ngx_http_request_t *r,
                    "http upstream ssl key: \"%s\"", key.data);
 
     if (ngx_ssl_connection_certificate(c, r->pool, &cert, &key,
+#if (nginx_version >= 1028000)
+                                       u->conf->ssl_certificate_cache,
+#endif
                                        u->conf->ssl_passwords)
         != NGX_OK)
     {


### PR DESCRIPTION
## What

Builds the module against nginx 1.28.x / 1.30.x in addition to the currently
supported 1.26.x. Three internal nginx APIs changed between the 1.26 and 1.28
stable branches; each is guarded with `#if (nginx_version >= 1028000)`, so the
1.26.x build path is left byte-for-byte unchanged.

- `ngx_http_parse_chunked()` gained a `keep_trailers` argument — pass `0`
  (preserves the previous behaviour of not keeping trailers).
- `ngx_http_upstream_conf_t.limit_rate` changed from `size_t` to
  `ngx_http_complex_value_t *` — evaluated with `ngx_http_complex_value_size()`.
- `ngx_ssl_connection_certificate()` gained an `ngx_ssl_cache_t *` argument —
  passed `u->conf->ssl_certificate_cache` (NULL when unset = no cache).

## Testing

Built as a dynamic module (`--add-dynamic-module`) against both stable branches:

- nginx 1.26.3 — old code path, compiles clean, `.so` produced.
- nginx 1.30.4 — new code path, compiles clean, `.so` produced.

No functional changes; the module's runtime behaviour is unchanged on 1.26.x.

## For v1.1 users

The old `v1.1` line needs the same three fixes to build on 1.28/1.30. A working
patch (on top of the `v1.1` tag) is here for anyone backporting:
https://gist.github.com/xandr0s/bd9f5ffbc38cc9eef856372fa806413f
